### PR TITLE
incorporate changes from the discussion

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,12 @@ makedocs(;
         edit_link = "main",
         assets = String[],
     ),
-    pages = ["Home" => "index.md"],
+    pages = [
+        "Home" => "index.md",
+        "`AbstractPermutation` interface" => "abstract_api.md",
+        "Other functions" => "misc.md",
+    ],
+    warnonly = [:missing_docs],
 )
 
 deploydocs(;

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -1,0 +1,108 @@
+```@meta
+CurrentModule = AbstractPermutations
+```
+
+# The `AbstractPermutation` interface
+
+The `AbstractPermutation` interface consists of just three mandatory functions.
+Note that none of them is exported, hence it is safe to `import`/`using`
+the package without introducing any naming conflicts with other packages.
+
+There are three obligatory methods are as follows:
+* a constructor,
+* `AbstractPermutations.degree` and
+* `Base.^`.
+
+!!! note
+    The meaning of `degree` doesn't have a well established tradition in
+    mathematics. This is still ok, as long as we define its meaning with care
+    for precision and use it in a consistent and predictable way.
+
+```@docs
+AbstractPermutation
+```
+
+```@docs
+degree
+```
+
+```@docs
+^(::Integer, ::AbstractPermutation)
+```
+
+Moreover there are two more internal, suplementary functions that may be
+overloaded by the implementer, if needed.
+
+```@docs
+inttype
+perm
+```
+
+## Example implementation
+
+For an example, very simple implementation of the `AbstractPermutation`
+interface you may find in `ExamplePerms` module defined in
+[`perms_by_images.jl`](https://github.com/kalmarek/AbstractPermutations.jl/blob/main/test/perms_by_images.jl).
+
+Here we provide an alternative implementation which keeps the internal
+storage at fixed length.
+
+### Obligatory methods
+
+```julia
+struct APerm{T} <: AbstractPermutations.AbstractPermutation
+    images::Vector{T}
+    degree::Int
+
+    function APerm{T}(v::AbstractVector{<:Integer}, check::Bool=true, degree=nothing)
+        if check
+            isperm(v) || throw(ArgumentError("v is not a permutation"))
+            if !isnothing(degree) && degree != __degree(v)
+                throw(ArgumentError("wrong degree was passed"))
+            end
+        end
+        return new{T}(v, something(degree, __degree(v)))
+    end
+end
+
+# for our convenience
+APerm(v::AbstractVector{T}, check=true) where T = APerm{T}(v, check)
+```
+
+Above we defined permutations by storing the vector of their images together
+with the computed degree.
+For completeness this `__degree`` could be computed as
+
+```julia
+function __degree(images::AbstractVector{<:Integer})
+    @inbounds for i in lastindex(images):-1:firstindex(images)
+        images[i] ≠ i && return i
+    end
+    return zero(firstindex(images))
+end
+```
+
+Now we need to implement the remaining two functions which will be simple enough:
+
+```julia
+AbstractPermutations.degree(p::APerm) = p.degree
+function Base.^(i::T, p::APerm) where {T}
+    deg = AbstractPermutations.degree(p)
+    # we need to make sure that we return something of type T
+    return 1 ≤ i ≤ deg ? convert(T, p.images[i]) : i
+end
+```
+
+With this the implementation is complete!
+
+### Suplementary Methods
+
+Since in `APerm{T}` we store images as a `Vector{T}`, to avoid spurious
+allocations we may define
+
+```julia
+AbstractPermutations.inttype(::Type{APerm{T}}) where T = T
+```
+
+There is no need to define `AbstractPermutations.perm` as `APerm` is already
+very low level and suitable for high performance code-paths.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,11 +4,20 @@ CurrentModule = AbstractPermutations
 
 # AbstractPermutations
 
-Documentation for [AbstractPermutations](https://github.com/kalmarek/AbstractPermutations.jl).
+The package defines an interface for abstract permutations.
+The general assumptions are as follows:
+We consider `AbstractPermutations` as bijective self-maps of
+``\mathbb{N} = \{1,2,\ldots\}``, i.e. the **positive integers** which are
+**finitely supported**. That means that for every permutation
+``\sigma \colon \mathbb{N} \to \mathbb{N}`` there are only finitely many
+``k\in \mathbb{N}`` such that the value of ``\sigma`` at ``k`` is different
+from ``k``.
 
-```@index
-```
+In practical terms this means that each permutation can be uniquely determined
+by inspecting a vector of it's values on set ``\{1, 2, \ldots, n\}`` for some
+``n``. By standard mathematical convention we will denote **the image** of
+``k`` under ``\sigma`` by ``k^{\sigma}``, to signify that the set of bijections
+_acts_ on ``\mathbb{N}``
+[**on the right**](https://en.wikipedia.org/wiki/Group_action#Right_group_action).
 
-```@autodocs
-Modules = [AbstractPermutations]
-```
+For the description of the julia interface see the next section.

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -1,0 +1,27 @@
+```@meta
+CurrentModule = AbstractPermutations
+```
+
+# Permutation specific functions
+
+```@docs
+isodd(::AbstractPermutation)
+iseven(::AbstractPermutation)
+sign(::AbstractPermutation)
+permtype
+cycles
+```
+
+# Function specific to actions on `1:n`
+
+```@docs
+firstmoved
+fixedpoints
+nfixedpoints
+```
+
+# The `@perm` macro
+
+```@docs
+@perm
+```

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -38,14 +38,15 @@ abstract type AbstractPermutation <: GroupsCore.GroupElement end
 
 """
     degree(σ::AbstractPermutation)
-Return a minimal number `n ≥ 1` such that `σ(k) == k` for all `k > n`,
+Return a minimal number `n ≥ 0` such that `σ(k) == k` for all `k > n`.
 
 Such number `n` can be understood as a _degree_ of a permutation, since we can
 regard `σ` as an element of `Sym(1:n)` (and not of `Sym(1:n-1)`).
 
 !!! note
-    By this convention `degree` of the trivial permutation is equal to `1` and
-    it is the only permutation with this property.
+    By this convention `degree` of the identity permutation is equal to `0`
+    and it is the only permutation with this property.
+    Also by this convention there is no permutation with `degree` equal to `1`.
 """
 function degree(σ::AbstractPermutation)
     throw(
@@ -122,9 +123,9 @@ function Base.convert(
     return P(__images_vector(p), false)
 end
 
-Base.one(::Type{P}) where {P<:AbstractPermutation} = P(inttype(P)[1], false)
+Base.one(::Type{P}) where {P<:AbstractPermutation} = P(inttype(P)[], false)
 Base.one(σ::AbstractPermutation) = one(typeof(σ))
-Base.isone(σ::AbstractPermutation) = degree(σ) == 1
+Base.isone(σ::AbstractPermutation) = degree(σ) == 0
 
 function _deepcopy(p::AbstractPermutation)
     return typeof(p)(__images_vector(p), false)

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -59,10 +59,10 @@ end
 
 """
     ^(i::Integer, σ::AbstractPermutation)
-Return the image of `i` under `σ`.
+Return the image of `i` under `σ` preserving the type of `i`.
 
 We consider `σ` as a permutation of `ℕ` (the positive integers), with finite
-support, so by convention `k^σ = k` for all `k > degree(σ)`.
+support, so `k^σ = k` for all `k > degree(σ)`.
 
 !!! warn
     The behaviour of `i^σ` for `i ≤ 0` is undefined and can not be relied upon.

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -78,7 +78,7 @@ end
 
 """
     perm(p::AbstractPermutation)
-Return the "bare-metal" permutation (unwrap).
+Return the "bare-metal" permutation (unwrap). Return `σ` by default.
 
 !!! warn
     **For internal use only.**

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -44,9 +44,7 @@ function Base.:(*)(σ::AbstractPermutation, τs::AbstractPermutation...)
     return typeof(σ)(img, false)
 end
 
-Base.:^(σ::AbstractPermutation, τ::AbstractPermutation) = conj(σ, τ)
-
-function Base.conj(σ::AbstractPermutation, τ::AbstractPermutation)
+function Base.:^(σ::AbstractPermutation, τ::AbstractPermutation)
     deg = max(degree(σ), degree(τ))
     img = Vector{inttype(σ)}(undef, deg)
     @inbounds for i in Base.OneTo(deg)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -55,6 +55,8 @@ Strings for the output of e.g. GAP could be copied directly into `@perm`, as lon
 they are not elided. Cycles of length `1` are not necessary, but can be included.
 
 # Examples:
+Using the exemplary implementation from `test/perms_by_images.jl`
+
 ```julia
 julia> p = @perm Perm{UInt16} "(1,3)(2,4)"
 (1,3)(2,4)

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -1,13 +1,22 @@
 """
-    parity(g::AbstractPermutation)
-Return the parity of number of factors in factorization of `g` into transpositions.
+    isodd(g::AbstractPermutation) -> Bool
+Return `true` if g is an odd permutation and `false` otherwise.
 
-Return `1` if the number is odd and `0` otherwise.
+An odd permutation decomposes into an odd number of transpositions.
 """
-parity(σ::AbstractPermutation) = __parity_generic(σ)
-parity(cd::CycleDecomposition) = Int(isodd(count(iseven ∘ length, cd)))
+Base.isodd(σ::AbstractPermutation) = __isodd(σ)
+Base.isodd(cd::CycleDecomposition) = isodd(count(iseven ∘ length, cd))
 
-function __parity_generic(σ::AbstractPermutation)
+"""
+    isodd(g::AbstractPermutation) -> Bool
+Return `true` if g is an even permutation and `false` otherwise.
+
+An even permutation decomposes into an even number of transpositions.
+"""
+Base.iseven(σ::AbstractPermutation) = !isodd(σ)
+Base.iseven(cd::CycleDecomposition) = !isodd(cd)
+
+function __isodd(σ::AbstractPermutation)
     to_visit = trues(degree(σ))
     parity = false
     k = 1
@@ -21,17 +30,17 @@ function __parity_generic(σ::AbstractPermutation)
             next = next^σ
         end
     end
-    return Int(parity)
+    return parity
 end
 
 """
     sign(g::AbstractPermutation)
-Return the sign of a permutation.
+Return the sign of a permutation as an integer `± 1`.
 
 `sign` represents the homomorphism from the permutation group to the unit group
 of `ℤ` whose kernel is the alternating group.
 """
-Base.sign(σ::AbstractPermutation) = ifelse(isone(parity(σ)), -1, 1)
+Base.sign(σ::AbstractPermutation) = ifelse(isodd(σ), -1, 1)
 
 """
     permtype(g::AbstractPermutation)

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -55,11 +55,11 @@ function permtype(σ::AbstractPermutation)
 end
 
 """
-    firstmoved(g::AbstractPermutation[, range = 1:degree(g)])
+    firstmoved(g::AbstractPermutation, range)
 Return the first point from `range` that is moved by `g`, or `nothing`
 if `g` fixes `range` point-wise.
 """
-function firstmoved(σ::AbstractPermutation, range = Base.OneTo(degree(σ)))
+function firstmoved(σ::AbstractPermutation, range)
     all(>(degree(σ)), range) && return nothing
     for i in range
         if i^σ ≠ i
@@ -70,11 +70,11 @@ function firstmoved(σ::AbstractPermutation, range = Base.OneTo(degree(σ)))
 end
 
 """
-    fixedpoints(g::AbstractPermutation[, range = 1:degree(g)])
+    fixedpoints(g::AbstractPermutation, range)
 Return the vector of points in `range` fixed by `g`.
 """
-function fixedpoints(σ::AbstractPermutation, range = Base.OneTo(degree(σ)))
-    all(>(degree(σ)), range) && return eltype(range)[]
+function fixedpoints(σ::AbstractPermutation, range)
+    all(>(degree(σ)), range) && return [i for i in range]
     return [i for i in range if i^σ == i]
 end
 
@@ -82,8 +82,9 @@ end
     nfixedpoints(g::AbstractPermutation[, range = 1:degree(g)])
 Return the number of points in `range` fixed by `g`.
 """
-function nfixedpoints(σ::AbstractPermutation, range = Base.OneTo(degree(σ)))
-    return count(i -> i^σ == i, range)
+function nfixedpoints(σ::AbstractPermutation, range)
+    all(>(degree(σ)), range) && return length(range)
+    return count(i -> i^σ == i, range; init = 0)
 end
 
 function GroupsCore.order(::Type{T}, σ::AbstractPermutation) where {T}

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -8,16 +8,15 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
         @test one(p) isa AP.AbstractPermutation
 
         @testset "the identity permutation" begin
-            a = P([1, 2, 3])
-            @test isone(a)
-            @test a == one(a)
-            @test isone(one(a))
-            @test isone(AP.degree(a))
-            @test AP.degree(a) == 1
+            id = P([1, 2, 3])
+            @test isone(id)
+            @test id == one(id)
+            @test isone(one(id))
+            @test AP.degree(id) == 0
 
-            @test collect(AP.cycles(a)) == [[1]]
+            @test collect(AP.cycles(id)) == Vector{Int}[]
 
-            @test all(i -> i^a == i, 1:5)
+            @test all(i -> i^p == i, 1:5)
         end
 
         @testset "same permutations" begin

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -63,7 +63,7 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
         end
 
         @testset "actions on 1:n" begin
-            p = P([1])
+            id = P([1]) # ()
             a = P([2, 1, 3]) # (1,2)
             b = P([2, 3, 1]) # (1,2,3)
             c = P([1, 2, 3, 5, 4]) # (4,5)
@@ -73,29 +73,30 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
             @test 2^a == 1
             @test (3:7) .^ a == 3:7
             @test (1:5) .^ b == [2, 3, 1, 4, 5]
-            @test (1:10) .^ p == 1:10
+            @test (1:10) .^ id == 1:10
 
             # action preserves type
             @test UInt128(1)^a isa UInt128
             @test UInt32(100)^a isa UInt32
-            @test UInt8(100)^p isa UInt8
+            @test UInt8(100)^id isa UInt8
 
-            @test AP.firstmoved(a) == 1
-            @test AP.firstmoved(b) == 1
-            @test AP.firstmoved(c) == 4
-            @test AP.firstmoved(p) === nothing
+            @test AP.firstmoved(a, 1:AP.degree(a)) == 1
+            @test AP.firstmoved(b, 2:5) == 2
+            @test AP.firstmoved(c, 1:3) === nothing
+            @test AP.firstmoved(c, 1:5) == 4
+            @test AP.firstmoved(id, 5:10) === nothing
 
-            @test AP.nfixedpoints(p) == 1
-            @test AP.nfixedpoints(b) == 0
+            @test AP.nfixedpoints(id, 1:AP.degree(id)) == 0
+            @test AP.nfixedpoints(b, 1:AP.degree(b)) == 0
             @test AP.nfixedpoints(b, 2:5) == 2
-            @test AP.nfixedpoints(c) == 3
+            @test AP.nfixedpoints(c, 1:AP.degree(c)) == 3
             @test AP.nfixedpoints(c, 4:5) == 0
 
-            @test AP.fixedpoints(b) == Int[]
+            @test AP.fixedpoints(b, 1:AP.degree(b)) == Int[]
             @test AP.fixedpoints(b, 2:5) == [4, 5]
-            @test AP.fixedpoints(c) == [1, 2, 3]
+            @test AP.fixedpoints(c, 1:3) == [1, 2, 3]
             @test AP.fixedpoints(c, 2:4) == [2, 3]
-            @test AP.fixedpoints(p) == [1]
+            @test AP.fixedpoints(id, 5:7) == 5:7
         end
 
         @testset "permutation functions" begin

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -99,35 +99,35 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
         end
 
         @testset "permutation functions" begin
-            p = P([1]) # ()
+            id = P([1]) # ()
             a = P([2, 1, 3]) # (1,2)
             b = P([2, 3, 1]) # (1,2,3)
             c = P([1, 2, 3, 5, 4]) # (4,5)
-            @test AP.permtype(p) == Int[]
+            @test AP.permtype(id) == Int[]
             @test AP.permtype(a) == [2]
             @test AP.permtype(b) == [3]
             @test AP.permtype(b * c) == [3, 2]
 
-            @test sign(p) == 1
+            @test sign(id) == 1
             @test sign(a) == -1
             @test sign(b) == 1
             @test sign(c) == -1
             @test sign(a * b) == -1
             @test sign(a * b * c) == 1
 
-            @test AP.parity(p) == 0
-            @test AP.parity(a) == 1
-            @test AP.parity(b) == 0
-            @test AP.parity(a * b) == 1
-            @test AP.parity(a * b * c) == 0
+            @test isodd(id) == false == !iseven(id)
+            @test isodd(a) == true == !iseven(a)
+            @test isodd(b) == false == !iseven(b)
+            @test isodd(a * b) == true == !iseven(a * b)
+            @test isodd(a * b * c) == false == !iseven(a * b * c)
 
-            @test AP.parity(AP.cycles(p)) == 0
-            @test AP.parity(AP.cycles(a)) == 1
-            @test AP.parity(AP.cycles(b)) == 0
-            @test AP.parity(AP.cycles(a * b)) == 1
-            @test AP.parity(AP.cycles(a * b * c)) == 0
+            @test iseven(AP.cycles(id))
+            @test isodd(AP.cycles(a))
+            @test iseven(AP.cycles(b))
+            @test isodd(AP.cycles(a * b))
+            @test iseven(AP.cycles(a * b * c))
 
-            @test AP.order(p) == 1
+            @test AP.order(id) == 1
             @test AP.order(a) == 2
             @test AP.order(b) == 3
             @test AP.order(c) == 2
@@ -135,7 +135,6 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
             @test AP.order(a * b) == 2
             @test AP.order(a * b * c) == 2
 
-            @test collect(AP.cycles(p)) == [[1]]
             @test collect(AP.cycles(a)) == [[1, 2]]
             @test collect(AP.cycles(b)) == [[1, 2, 3]]
             @test collect(AP.cycles(a * b)) == [[1, 3], [2]]

--- a/test/perms_by_images.jl
+++ b/test/perms_by_images.jl
@@ -5,7 +5,7 @@ function __degree(images::AbstractVector{<:Integer})
     @inbounds for i in lastindex(images):-1:firstindex(images)
         images[i] ≠ i && return i
     end
-    return firstindex(images)
+    return zero(firstindex(images))
 end
 
 struct Perm{T<:Integer} <: AP.AbstractPermutation # change to mutable for cycles


### PR DESCRIPTION
* make `degree` null again:
  * before: no permutation of degree `0` and `id` is the only permutation with degree `1`.
  * after: no permutation of degree `1` and `id` is the only permutation with degree `0`.
  * Benefits: save 64b of memory for `id`!
* turn `parity` into `Base.isodd` and `Base.iseven`
* remove the default values for the second arguments of `firstmoved`, `fixedpoints`, `nfixedpoints`
* remove method for `Base.conj`
* Flash the first version of the documentation and tighten the docs
  * `i^p` should preserve the type of `i`