### PR TITLE
small fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractPermutations"
 uuid = "36d08e8a-54dd-435f-8c9e-38a475050b11"
 authors = ["Marek Kaluba <kalmar@mailbox.org>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,45 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://kalmarek.github.io/AbstractPermutations.jl/dev/)
 [![CI](https://github.com/kalmarek/AbstractPermutations.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/kalmarek/AbstractPermutations.jl/actions/workflows/CI.yml)
 [![Coverage](https://codecov.io/gh/kalmarek/AbstractPermutations.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/kalmarek/AbstractPermutations.jl)
+
+This julia package provide a basis for inteoperability between different implementations of permutations in julia.
+The interface is based on four preconditions:
+
+* subtyping `AbstractPermutations.AbstractPermutation`, and
+* implementing a constructor from vector of `images`, and
+* implementing methods for
+  * `AbstractPermutations.degree(::AbstractPermutation)` and
+  * `Base.^(::Integer, ::AbstractPermutation)`,
+
+and two conventions:
+
+* `AbstractPermutations` are finitely supported bijections of `N` (the positive integers)
+* `AbstractPermutations` act on `N` from the right (and therefore `(1,2)·(1,2,3) == (1,3)`).
+
+With implementing the interface one receives not only consistent arithmetic **across** different implementations of the interface but also the possibility to run permutation groups algorithms from package following the interface
+
+The packages following `AbstractPermutation` interface:
+
+* [`PermutationGroups.jl`](https://github.com/kalmarek/PermutationGroups.jl) (work in progress)
+* [`PermGroups.jl`](https://github.com/jmichel7/PermGroups.jl/) (to be confirmed).
+
+## Testing of the interface
+
+We provide test suite for the interface. If `APerm` is your implementation you can test it via the following.
+
+```julia
+julia> using AbstractPermutations
+
+julia> include(joinpath(pkgdir(AbstractPermutations), "test", "abstract_perm_API.jl"))
+abstract_perm_interface_test (generic function with 1 method)
+
+julia> include(joinpath(pkgdir(AbstractPermutations), "test", "perms_by_images.jl")) # include your own implementation
+Main.ExamplePerms
+
+julia> import .ExamplePerms
+
+julia> abstract_perm_interface_test(ExamplePerms.Perm);
+Test Summary:                                        | Pass  Total  Time
+AbstractPermutation API test: Main.ExamplePerms.Perm |   95     95  0.3s
+
+```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The packages following `AbstractPermutation` interface:
 * [`PermutationGroups.jl`](https://github.com/kalmarek/PermutationGroups.jl) (work in progress)
 * [`PermGroups.jl`](https://github.com/jmichel7/PermGroups.jl/) (to be confirmed).
 
+> Note that [`Permutations.jl`](https://github.com/scheinerman/Permutations.jl) **do not** implement the `AbstractPermutations.jl` interface due to the fact that they act on integers **on the left**. See [these](https://github.com/scheinerman/Permutations.jl/issues/42#issuecomment-1826868005) [comments](https://github.com/scheinerman/Permutations.jl/issues/42#issuecomment-1830242636).
+
 ## Testing of the interface
 
 We provide test suite for the interface. If `APerm` is your implementation you can test it via the following.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ DocMeta.setdocmeta!(
 makedocs(;
     modules = [AbstractPermutations],
     authors = "Marek Kaluba <kalmar@mailbox.org>",
-    repo = "https://github.com/kalmarek/AbstractPermutations.jl/blob/{commit}{path}#{line}",
+    repo = Documenter.Remotes.GitHub("kalmarek", "AbstractPermutations.jl"),
     sitename = "AbstractPermutations.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -49,7 +49,7 @@ storage at fixed length.
 
 ### Implementing Obligatory methods
 
-```jldoctest APerm; output=false
+```@example APerm
 import AbstractPermutations
 struct APerm{T} <: AbstractPermutations.AbstractPermutation
     images::Vector{T}
@@ -62,50 +62,41 @@ struct APerm{T} <: AbstractPermutations.AbstractPermutation
         return new{T}(v, __degree(v))
     end
 end
-
-# for our convenience we define
-APerm(v::AbstractVector{T}, check=true) where T = APerm{T}(v, check)
-
-# output
-APerm
+nothing # hide
 ```
 
 Above we defined permutations by storing the vector of their images together
 with the computed degree.
 For completeness this `__degree`` could be computed as
 
-```jldoctest APerm; output=false
+```@example APerm
 function __degree(images::AbstractVector{<:Integer})
     @inbounds for i in lastindex(images):-1:firstindex(images)
         images[i] ≠ i && return i
     end
     return zero(firstindex(images))
 end
-
-# output
-__degree (generic function with 1 method)
+nothing # hide
 ```
 
 Now we need to implement the remaining two functions which will be simple enough:
 
-```jldoctest APerm; output=false
+```@example APerm
 AbstractPermutations.degree(p::APerm) = p.degree
 function Base.:^(i::Integer, p::APerm)
     deg = AbstractPermutations.degree(p)
     # make sure that we return something of the same type as `i`
     return 1 ≤ i ≤ deg ? oftype(i, p.images[i]) : i
 end
-
-# output
+nothing # hide
 ```
 
 With this the implementation is complete! To test if the implementation follows the specification a test suite is provided:
 
-```jldoctest APerm
+```@example APerm
 include(joinpath(pkgdir(AbstractPermutations), "test", "abstract_perm_API.jl"))
-abstract_perm_interface_test(APerm)
-nothing # to hide output
-# output
+abstract_perm_interface_test(APerm{UInt16})
+nothing # hide
 ```
 
 ### Suplementary Methods

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -101,14 +101,11 @@ end
 
 With this the implementation is complete! To test if the implementation follows the specification a test suite is provided:
 
-```jldoctest APerm; filter = [r"\|\s+(\d+\s+)+(\d+\.\d+s)", r"Test\.DefaultTestSet(.*)"]
+```jldoctest APerm
 include(joinpath(pkgdir(AbstractPermutations), "test", "abstract_perm_API.jl"))
-abstract_perm_interface_test(APerm);
-
+abstract_perm_interface_test(APerm)
+nothing # to hide output
 # output
-Test Summary:                                                    | Pass  Total  Time
-AbstractPermutation API test: APerm |   95     95  0.4s
-Test.DefaultTestSet("AbstractPermutation API test: APerm", Any[Test.DefaultTestSet("the identity permutation", Any[], 7, false, false, true, 1.701268412377077e9, 1.701268412390534e9, false), Test.DefaultTestSet("same permutations", Any[], 13, false, false, true, 1.701268412390564e9, 1.701268412390592e9, false), Test.DefaultTestSet("group arithmetic", Any[], 11, false, false, true, 1.701268412390603e9, 1.701268412454585e9, false), Test.DefaultTestSet("actions on 1:n", Any[], 23, false, false, true, 1.701268412454622e9, 1.701268412454663e9, false), Test.DefaultTestSet("permutation functions", Any[], 31, false, false, true, 1.701268412454673e9, 1.701268412454732e9, false), Test.DefaultTestSet("io/show and parsing", Any[], 9, false, false, true, 1.70126841245474e9, 1.701268412497615e9, false)], 1, false, false, true, 1.701268412376839e9, 1.70126841249762e9, false)
 ```
 
 ### Suplementary Methods

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -123,6 +123,8 @@ function Base.convert(
     return P(__images_vector(p), false)
 end
 
+Base.convert(::Type{P}, p::P) where {P<:AbstractPermutation} = p
+
 Base.one(::Type{P}) where {P<:AbstractPermutation} = P(inttype(P)[], false)
 Base.one(σ::AbstractPermutation) = one(typeof(σ))
 Base.isone(σ::AbstractPermutation) = degree(σ) == 0

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -1,3 +1,5 @@
+using Test
+import AbstractPermutations as AP
 function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
     @testset "AbstractPermutation API test: $P" begin
         @test P([1]) isa AP.AbstractPermutation

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -24,13 +24,14 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
         @testset "the identity permutation" begin
             id = P([1, 2, 3])
             @test isone(id)
+            @test one(id) isa AP.AbstractPermutation
             @test id == one(id)
             @test isone(one(id))
             @test AP.degree(id) == 0
 
             @test collect(AP.cycles(id)) == Vector{Int}[]
 
-            @test all(i -> i^p == i, 1:5)
+            @test all(i -> i^id == i, 1:5)
         end
 
         @testset "same permutations" begin

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -3,11 +3,23 @@ import AbstractPermutations as AP
 function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
     @testset "AbstractPermutation API test: $P" begin
         @test P([1]) isa AP.AbstractPermutation
-        @test_throws ArgumentError P([2])
-        @test_throws ArgumentError P([1, 2, 3, 1])
+        try
+            P([2])
+            @warn "$P doesn't perform image vector validation, use it with care!"
+        catch e
+            if !(e isa ArgumentError)
+                rethrow(e)
+            end
+        end
 
-        p = P([1])
-        @test one(p) isa AP.AbstractPermutation
+        try
+            P([1, 2, 3, 1])
+            @warn "$P doesn't perform image vector validation, use it with care!"
+        catch e
+            if !(e isa ArgumentError)
+                rethrow(e)
+            end
+        end
 
         @testset "the identity permutation" begin
             id = P([1, 2, 3])


### PR DESCRIPTION
@jmichel7 this changes the behaviour of the constructor on invalid images vector (`ArgumentError` is non compulsory, a warning when validating the implementation with test suite will be shown instead).

I think it's best to do this now to get things going first; We can return to the discussion in a moment. Changing all of the constructor calls even in 40k lines of code should be easy using e.g. vscode.

The basic README is added due to a request in https://github.com/JuliaRegistries/General/pull/95852