### PR TITLE
optimize the generic operations

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install JuliaFormatter and format
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.9"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.42"))'
           julia  -e 'using JuliaFormatter; format(["./src", "./test"], verbose=true)'
       - name: Format check
         run: |

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "0.2.0"
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
 
 [compat]
-julia = "1.6"
 GroupsCore = "0.4"
+julia = "1.6"
+Random = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractPermutations"
 uuid = "36d08e8a-54dd-435f-8c9e-38a475050b11"
 authors = ["Marek Kaluba <kalmar@mailbox.org>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -106,16 +106,18 @@ Since in `APerm{T}` we store images as a `Vector{T}`, to avoid spurious
 allocations we may define
 
 ```julia
-AP.inttype(::Type{APerm{T}}) where T = T
+AbstractPermutations.inttype(::Type{APerm{T}}) where T = T
 ```
 
 There is no need to define `AbstractPermutations.perm` as `APerm` is already
 very low level and suitable for high performance code-paths.
 
-Finally to squeeze even more performance one could define `AP.__unsafe_image`
+Finally to squeeze even more performance one could define `__unsafe_image`
 with the same semantics as `n^σ` under the assumption that `n` belongs to
-`Base.OneTo(AP.degree(σ))`:
+`Base.OneTo(degree(σ))`:
 
 ```julia
-@inline AP.__unsafe_image(n::Integer, σ::APerm) = oftype(n, @inbounds σ.images[n])
+@inline function AbstractPermutations.__unsafe_image(n::Integer, σ::APerm)
+    return oftype(n, @inbounds σ.images[n])
+end
 ```

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -8,7 +8,10 @@ The `AbstractPermutation` interface consists of just three mandatory functions.
 Note that none of them is exported, hence it is safe to `import`/`using`
 the package without introducing any naming conflicts with other packages.
 
-There are three obligatory methods are as follows:
+## Mandatory methods
+
+The three mandatory methods are:
+
 * a constructor,
 * `AbstractPermutations.degree` and
 * `Base.^`.
@@ -30,8 +33,10 @@ degree
 ^(::Integer, ::AbstractPermutation)
 ```
 
-Moreover there are two more internal, suplementary functions that may be
-overloaded by the implementer, if needed.
+## Suplementary methods
+
+Moreover there are three internal, suplementary functions that may be overloaded
+by the implementer, if needed (mostly for performance reasons).
 
 ```@docs
 inttype
@@ -48,7 +53,7 @@ interface you may find in `ExamplePerms` module defined in
 Here we provide an alternative implementation which keeps the internal
 storage at fixed length.
 
-### Implementing Obligatory methods
+### Implementing mandatory methods
 
 ```@example APerm
 import AbstractPermutations
@@ -68,14 +73,12 @@ nothing # hide
 
 Above we defined permutations by storing the vector of their images together
 with the computed degree.
-For completeness this `__degree`` could be computed as
+For completeness this `__degree` could be computed as
 
 ```@example APerm
 function __degree(images::AbstractVector{<:Integer})
-    @inbounds for i in lastindex(images):-1:firstindex(images)
-        images[i] ≠ i && return i
-    end
-    return zero(firstindex(images))
+    k = findlast(i->images[i] ≠ i, eachindex(images))
+    return something(k, 0)
 end
 nothing # hide
 ```
@@ -92,7 +95,8 @@ end
 nothing # hide
 ```
 
-With this the implementation is complete! To test if the implementation follows the specification a test suite is provided:
+With this the interface is implementation is complete. To test whether the implementation
+follows the specification a test suite is provided:
 
 ```@example APerm
 include(joinpath(pkgdir(AbstractPermutations), "test", "abstract_perm_API.jl"))

--- a/docs/src/abstract_api.md
+++ b/docs/src/abstract_api.md
@@ -36,6 +36,7 @@ overloaded by the implementer, if needed.
 ```@docs
 inttype
 perm
+__unsafe_image
 ```
 
 ## Example implementation
@@ -110,3 +111,11 @@ AP.inttype(::Type{APerm{T}}) where T = T
 
 There is no need to define `AbstractPermutations.perm` as `APerm` is already
 very low level and suitable for high performance code-paths.
+
+Finally to squeeze even more performance one could define `AP.__unsafe_image`
+with the same semantics as `n^σ` under the assumption that `n` belongs to
+`Base.OneTo(AP.degree(σ))`:
+
+```julia
+@inline AP.__unsafe_image(n::Integer, σ::APerm) = oftype(n, @inbounds σ.images[n])
+```

--- a/src/AbstractPermutations.jl
+++ b/src/AbstractPermutations.jl
@@ -5,6 +5,7 @@ import GroupsCore: GroupElement, order, InterfaceNotImplemented # only these two
 
 include("cycle_decomposition.jl")
 include("abstract_perm.jl")
+include("io.jl")
 include("arithmetic.jl")
 include("perm_functionality.jl")
 include("parsing.jl")

--- a/src/AbstractPermutations.jl
+++ b/src/AbstractPermutations.jl
@@ -3,8 +3,8 @@ module AbstractPermutations
 import GroupsCore
 import GroupsCore: GroupElement, order, InterfaceNotImplemented # only these two are extended
 
-include("cycle_decomposition.jl")
 include("abstract_perm.jl")
+include("cycle_decomposition.jl")
 include("io.jl")
 include("arithmetic.jl")
 include("perm_functionality.jl")

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -123,8 +123,11 @@ end
 
 # utilities for Abstract Permutations
 
-function __images_vector(p::AbstractPermutation, n = degree(p))
-    return inttype(p)[i^p for i in Base.OneTo(n)]
+function __images_vector(p::AbstractPermutation)
+    img = let ^ = __unsafe_image
+        inttype(p)[i^p for i in Base.OneTo(degree(p))]
+    end
+    return img
 end
 
 function Base.convert(
@@ -153,9 +156,11 @@ Base.copy(p::AbstractPermutation) = _deepcopy(p)
 
 function Base.:(==)(σ::AbstractPermutation, τ::AbstractPermutation)
     degree(σ) ≠ degree(τ) && return false
-    @inbounds for i in Base.OneTo(degree(σ))
-        if i^σ != i^τ
-            return false
+    let ^ = __unsafe_image
+        for i in Base.OneTo(degree(σ))
+            if i^σ != i^τ
+                return false
+            end
         end
     end
     return true
@@ -163,8 +168,10 @@ end
 
 function Base.hash(σ::AbstractPermutation, h::UInt)
     h = hash(AbstractPermutation, h)
-    @inbounds for i in Base.OneTo(degree(σ))
-        h = hash(i^σ, h)
+    let ^ = __unsafe_image
+        for i in Base.OneTo(degree(σ))
+            h = hash(i^σ, h)
+        end
     end
     return h
 end

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -33,6 +33,7 @@ Subtypes `APerm <: AbstractPermutation` must implement the following functions:
 * [`perm(σ::APerm)`](@ref perm) by default returns `σ` - the "simplest"
   (implementation-wise) permutation underlying `σ`.
 * [`inttype(::Type{<:APerm})`](@ref inttype) by default returns `UInt32`.
+* [`__unsafe_image(i::Integer, σ::APerm)`](@ref __unsafe_image) defaults to `i^σ`.
 """
 abstract type AbstractPermutation <: GroupsCore.GroupElement end
 

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -108,7 +108,7 @@ Return the underlying "storage" integer.
 !!! warn
     **For internal use only.**
 
-The intension is to provide optimal storage type when the `images` vector
+The intention is to provide optimal storage type when the `images` vector
 constructor is used (to save allocations and memory copy).
 For example a hypothetic permutation `Perm8` of elements up to length `255`
 may alter the default to `UInt8`.

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -13,7 +13,7 @@ Subtypes `APerm <: AbstractPermutation` must implement the following functions:
   constitute a honest permutation.
 * [`Base.:^(i::Integer, σ::APerm)`](@ref ^(::Integer, ::AbstractPermutation))
   the customary notation for the image of `i` under `σ`.
-* [`degree(σ::APerm)`](@ref degree) the minimal `d ≥ 1` such that `σ` fixes all
+* [`degree(σ::APerm)`](@ref degree) the minimal `d ≥ 0` such that `σ` fixes all
   `k ≥ d`.
 
 !!! note
@@ -95,10 +95,12 @@ Return the "bare-metal" permutation (unwrap). Return `σ` by default.
 !!! warn
     **For internal use only.**
 
-Access to wrapped permutation object. For "bare-metal" permutations this needs
-to return the identical (i.e. ``===`) object. The intention of ths functions
-is to provide un-wrapped permutations to computationally intensive algorithms,
-so that the external wrappers (if exist) do not hinder the performance.
+Provide access to wrapped permutation object. For "bare-metal" permutations this
+method needs to return the identical (i.e. ``===`) object.
+
+The intention of this method is to provide an un-wrapped permutations to
+computationally intensive algorithms, so that the external wrappers (if present)
+do not hinder the performance.
 """
 perm(p::AbstractPermutation) = p
 

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -77,6 +77,17 @@ function Base.:^(::Integer, σ::AbstractPermutation)
 end
 
 """
+    __unsafe_image(i::Integer, σ::AbstractPermutation)
+The same as `i^σ`, but assuming that `i ∈ Base.OneTo(degree(σ))`.
+
+!!! warn
+    The caller is responsible for checking the assumption.
+    Failure to do so may (and probably will) lead to segfaults in the best
+    case scenario and to silent data corruption in the worst!.
+"""
+__unsafe_image(i::Integer, σ::AbstractPermutation) = i^σ
+
+"""
     perm(p::AbstractPermutation)
 Return the "bare-metal" permutation (unwrap). Return `σ` by default.
 

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -197,32 +197,3 @@ function CycleDecomposition(σ::AbstractPermutation)
     end
     return CycleDecomposition{T}(cycles, cyclesptr)
 end
-
-# IO
-
-function Base.show(io::IO, ::MIME"text/plain", g::AbstractPermutation)
-    return _print_perm(io, g)
-end
-
-function _print_perm(
-    io::IO,
-    p::AbstractPermutation,
-    width::Integer = last(displaysize(io)),
-)
-    if isone(p)
-        return print(io, "()")
-    else
-        for c in cycles(p)
-            length(c) == 1 && continue
-            cyc = join(c, ",")
-
-            if width ≥ length(cyc) + 2
-                print(io, "(", cyc, ")")
-                width -= length(cyc) + 2
-            else
-                print(io, "(", SubString(cyc, 1, width - 3), " …")
-                break
-            end
-        end
-    end
-end

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -176,35 +176,3 @@ Base.broadcastable(p::AbstractPermutation) = Ref(p)
 Return an iterator over cycles in the disjoint cycle decomposition of `g`.
 """
 cycles(σ::AbstractPermutation) = CycleDecomposition(σ)
-
-function CycleDecomposition(σ::AbstractPermutation)
-    T = inttype(σ)
-    deg = degree(σ)
-
-    # allocate vectors of the expected size
-    visited = falses(deg)
-    cycles = Vector{T}(undef, deg)
-    # expected number of cycles - (overestimation of) the harmonic
-    cyclesptr = Vector{T}(undef, 5 + ceil(Int, Base.log(deg + 1)))
-
-    # shrink them accordingly
-    resize!(cycles, 0)
-    resize!(cyclesptr, 1)
-    cyclesptr[begin] = 1
-
-    @inbounds for idx in Base.OneTo(deg)
-        visited[idx] && continue
-        first_pt = idx
-
-        push!(cycles, first_pt)
-        visited[first_pt] = true
-        next_pt = first_pt^σ
-        while next_pt ≠ first_pt
-            push!(cycles, next_pt)
-            visited[next_pt] = true
-            next_pt = next_pt^σ
-        end
-        push!(cyclesptr, length(cycles) + 1)
-    end
-    return CycleDecomposition{T}(cycles, cyclesptr)
-end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,17 +1,35 @@
 function Base.inv(σ::AbstractPermutation)
     img = Vector{inttype(σ)}(undef, degree(σ))
-    @inbounds for i in Base.OneTo(degree(σ))
-        img[i^σ] = i
+    let ^ = __unsafe_image
+        for i in Base.OneTo(degree(σ))
+            k = i^σ
+            @inbounds img[k] = i
+        end
     end
     return typeof(σ)(img, false)
 end
 
 function Base.:(*)(σ::AbstractPermutation, τ::AbstractPermutation)
-    deg = max(degree(σ), degree(τ))
-    img = Vector{inttype(σ)}(undef, deg)
-    @inbounds for i in Base.OneTo(deg)
-        k = (i^σ)^τ
-        img[i] = k
+    img = Vector{inttype(σ)}(undef, max(degree(σ), degree(τ)))
+    let ^ = __unsafe_image
+        if degree(σ) ≤ degree(τ)
+            for i in Base.OneTo(degree(σ))
+                k = (i^σ)^τ
+                @inbounds img[i] = k
+            end
+            for i in degree(σ)+1:degree(τ)
+                k = i^τ
+                @inbounds img[i] = k
+            end
+        else # degree(σ) > degree(τ)
+            for i in Base.OneTo(degree(σ))
+                k = i^σ
+                if k ≤ degree(τ)
+                    k = k^τ
+                end
+                @inbounds img[i] = k
+            end
+        end
     end
     return typeof(σ)(img, false)
 end
@@ -21,11 +39,63 @@ function Base.:(*)(
     τ::AbstractPermutation,
     ρ::AbstractPermutation,
 )
-    deg = max(degree(σ), degree(τ), degree(ρ))
+    degσ, degτ, degρ = degree(σ), degree(τ), degree(ρ)
+    deg = max(degσ, degτ, degρ)
     img = Vector{inttype(σ)}(undef, deg)
-    @inbounds for i in Base.OneTo(deg)
-        k = ((i^σ)^τ)^ρ
-        img[i] = k
+    let ^ = __unsafe_image
+        if degσ ≤ degτ ≤ degρ
+            for i in Base.OneTo(degσ)
+                k = ((i^σ)^τ)^ρ
+                @inbounds img[i] = k
+            end
+            for i in degσ+1:degτ
+                k = (i^τ)^ρ
+                @inbounds img[i] = k
+            end
+            for i in degτ+1:degρ
+                k = i^ρ
+                @inbounds img[i] = k
+            end
+        elseif degσ ≤ degτ # either degσ ≤ degρ < degτ OR degρ < degσ ≤ dτ
+            for i in Base.OneTo(degσ)
+                k = (i^σ)^τ
+                if k ≤ degρ
+                    k = k^ρ
+                end
+                @inbounds img[i] = k
+            end
+            for i in (degσ+1):degτ
+                k = i^τ
+                if k ≤ degρ
+                    k = k^ρ
+                end
+                @inbounds img[i] = k
+            end
+        elseif degτ < degσ ≤ degρ
+            for i in Base.OneTo(degσ)
+                k = i^σ
+                if k ≤ degτ
+                    k = k^τ
+                end
+                k = k^ρ
+                @inbounds img[i] = k
+            end
+            for i in degσ+1:degρ
+                k = i^ρ
+                @inbounds img[i] = k
+            end
+        elseif degτ < degσ # either degτ ≤ degρ < degσ OR degρ < degτ < degσ
+            for i in Base.OneTo(degσ)
+                k = i^σ
+                if k ≤ degτ
+                    k = k^τ
+                end
+                if k ≤ degρ
+                    k = k^ρ
+                end
+                @inbounds img[i] = k
+            end
+        end
     end
     return typeof(σ)(img, false)
 end
@@ -34,12 +104,12 @@ function Base.:(*)(σ::AbstractPermutation, τs::AbstractPermutation...)
     isempty(τs) && return σ
     deg = max(degree(σ), maximum(degree, τs))
     img = Vector{inttype(σ)}(undef, deg)
-    @inbounds for i in Base.OneTo(deg)
+    for i in Base.OneTo(deg)
         j = (i^σ)
         for τ in τs
             j = j^τ
         end
-        img[i] = j
+        @inbounds img[i] = j
     end
     return typeof(σ)(img, false)
 end
@@ -47,7 +117,7 @@ end
 function Base.:^(σ::AbstractPermutation, τ::AbstractPermutation)
     deg = max(degree(σ), degree(τ))
     img = Vector{inttype(σ)}(undef, deg)
-    @inbounds for i in Base.OneTo(deg)
+    for i in Base.OneTo(deg)
         img[i^τ] = (i^σ)^τ
     end
     P = typeof(σ)

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -38,22 +38,24 @@ function CycleDecomposition(σ::AbstractPermutation)
     cidx = 0
     cyclesptr[cptr_idx] = cidx + 1
 
-    for idx in Base.OneTo(deg)
-        visited[idx] && continue
-        first_pt = idx
-        cidx += 1
-
-        cycles[cidx] = first_pt
-        visited[first_pt] = true
-        next_pt = first_pt^σ
-        while next_pt ≠ first_pt
+    let ^ = __unsafe_image
+        for idx in Base.OneTo(deg)
+            @inbounds visited[idx] && continue
+            first_pt = idx
             cidx += 1
-            cycles[cidx] = next_pt
-            visited[next_pt] = true
-            next_pt = next_pt^σ
+
+            @inbounds cycles[cidx] = first_pt
+            @inbounds visited[first_pt] = true
+            next_pt = first_pt^σ
+            while next_pt ≠ first_pt
+                cidx += 1
+                @inbounds cycles[cidx] = next_pt
+                @inbounds visited[next_pt] = true
+                next_pt = next_pt^σ
+            end
+            cptr_idx += 1 # we finished the cycle
+            @inbounds cyclesptr[cptr_idx] = cidx + 1
         end
-        cptr_idx += 1 # we finished the cycle
-        cyclesptr[cptr_idx] = cidx + 1
     end
     resize!(cycles, cidx)
     resize!(cyclesptr, cptr_idx)

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -23,3 +23,39 @@ function Base.show(io::IO, cd::CycleDecomposition)
         print(io, ')')
     end
 end
+
+function CycleDecomposition(σ::AbstractPermutation)
+    T = inttype(σ)
+    deg = degree(σ)
+
+    # allocate vectors of the expected size
+    cycles = Vector{T}(undef, deg)
+    visited = falses(deg)
+    # the upper bound for the number of cycles
+    cyclesptr = zeros(T, deg + 1)
+
+    cptr_idx = 1
+    cidx = 0
+    cyclesptr[cptr_idx] = cidx + 1
+
+    for idx in Base.OneTo(deg)
+        visited[idx] && continue
+        first_pt = idx
+        cidx += 1
+
+        cycles[cidx] = first_pt
+        visited[first_pt] = true
+        next_pt = first_pt^σ
+        while next_pt ≠ first_pt
+            cidx += 1
+            cycles[cidx] = next_pt
+            visited[next_pt] = true
+            next_pt = next_pt^σ
+        end
+        cptr_idx += 1 # we finished the cycle
+        cyclesptr[cptr_idx] = cidx + 1
+    end
+    resize!(cycles, cidx)
+    resize!(cyclesptr, cptr_idx)
+    return CycleDecomposition{T}(cycles, cyclesptr)
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,53 @@
+# IO
+
+function Base.show(io::IO, ::MIME"text/plain", g::AbstractPermutation)
+    ioc = convert(IOContext, io)
+    r, c = displaysize(io)
+    available_width = get(ioc, :limit, false) ? (r ÷ 2) * (c - 5) : typemax(Int)
+    k = __print_perm(ioc, g; available_width = available_width)
+    if !iszero(k)
+        print(ioc, '\n', lpad("[output truncated]", c - 5))
+    end
+end
+
+function Base.show(io::IO, g::AbstractPermutation)
+    ioc = convert(IOContext, io)
+    r, c = displaysize(io)
+    available_width = get(ioc, :limit, false) ? c - 5 : typemax(Int)
+    return __print_perm(ioc, g; available_width = available_width)
+end
+
+function __print_perm(
+    io::IOContext,
+    p::AbstractPermutation;
+    available_width::Integer,
+)
+    if !(get(io, :typeinfo, Nothing) <: AbstractPermutation)
+        str = sprint(show, typeof(p))
+        print(io, str, " ")
+        available_width -= length(str) + 1
+    end
+
+    if isone(p)
+        return print(io, "()")
+    else
+        for (i, c) in enumerate(cycles(p))
+            trunc, available_width = __print_cycle(io, c, available_width)
+            trunc && return i
+        end
+    end
+    return 0
+end
+
+function __print_cycle(io::IO, cycle, available_width)
+    length(cycle) == 1 && return false, available_width
+
+    str = join(cycle, ',')
+    truncated = length(str) + 2 > available_width
+    if truncated
+        print(io, '(', SubString(str, 1, available_width - 5), " … )")
+    else
+        print(io, '(', str, ')')
+    end
+    return truncated, available_width - (length(str) + 2)
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -29,7 +29,7 @@ function __print_perm(
     end
 
     if isone(p)
-        return print(io, "()")
+        print(io, "()")
     else
         for (i, c) in enumerate(cycles(p))
             trunc, available_width = __print_cycle(io, c, available_width)

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -35,7 +35,7 @@ end
 
 """
     sign(g::AbstractPermutation)
-Return the sign of a permutation as an integer `± 1`.
+Return the sign of a permutation as an integer `±1`.
 
 `sign` represents the homomorphism from the permutation group to the unit group
 of `ℤ` whose kernel is the alternating group.
@@ -47,8 +47,9 @@ Base.sign(σ::AbstractPermutation) = ifelse(isodd(σ), -1, 1)
 Return the group-theoretic type of permutation `g`, i.e. the vector of lengths
 of cycles in the (disjoint) cycle decomposition of `g`.
 
-The lengths are sorted in decreasing order and cycles of length `1` are omitted.
-`permtype(g)` fully determines the conjugacy class of `g` in the full symmetric group.
+The lengths are sorted in decreasing order and cycles of length `1` are
+omitted. `permtype(g)` fully determines the conjugacy class of `g` in the full
+symmetric group.
 """
 function permtype(σ::AbstractPermutation)
     return sort!([length(c) for c in cycles(σ) if length(c) > 1]; rev = true)
@@ -79,7 +80,7 @@ function fixedpoints(σ::AbstractPermutation, range)
 end
 
 """
-    nfixedpoints(g::AbstractPermutation[, range = 1:degree(g)])
+    nfixedpoints(g::AbstractPermutation, range)
 Return the number of points in `range` fixed by `g`.
 """
 function nfixedpoints(σ::AbstractPermutation, range)

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -74,7 +74,7 @@ end
 Return the vector of points in `range` fixed by `g`.
 """
 function fixedpoints(σ::AbstractPermutation, range)
-    all(>(degree(σ)), range) && return [i for i in range]
+    all(>(degree(σ)), range) && return collect(range)
     return [i for i in range if i^σ == i]
 end
 

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -169,6 +169,8 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
 
             @test parse(P, "(1,3)(2,4,6)(3,5)") isa AP.AbstractPermutation
             @test parse(P, "(1,3)(2,4,6)(3,5)") == P([5, 4, 1, 6, 3, 2])
+            @test deepcopy(c) == c
+            @test deepcopy(c) !== c
         end
     end
 end

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -162,11 +162,6 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
             a = P([2, 1, 3]) # (1,2)
             b = P([2, 3, 1]) # (1,2,3)
             c = P([1, 2, 3, 5, 4]) # (4,5)
-            @test sprint(show, MIME"text/plain"(), p) == "()"
-            @test sprint(show, MIME"text/plain"(), a) == "(1,2)"
-            @test sprint(show, MIME"text/plain"(), b) == "(1,2,3)"
-            @test sprint(show, MIME"text/plain"(), c) == "(4,5)"
-            @test sprint(show, MIME"text/plain"(), b * c) == "(1,2,3)(4,5)"
 
             @test sprint(show, AP.cycles(b)) == "Cycle Decomposition: (1,2,3)"
             @test sprint(show, AP.cycles(b * c)) ==

--- a/test/example_perms_tests.jl
+++ b/test/example_perms_tests.jl
@@ -1,0 +1,42 @@
+@testset "ExamplePerms" begin
+    abstract_perm_interface_test(EP.Perm)
+
+    p = EP.Perm([1]) # ()
+    a = EP.Perm([2, 1, 3]) # (1,2)
+    b = EP.Perm([2, 3, 1]) # (1,2,3)
+    c = EP.Perm([1, 2, 3, 5, 4]) # (4,5)
+
+    @test contains(sprint(show, MIME"text/plain"(), p), "()")
+    @test contains(sprint(show, MIME"text/plain"(), a), "(1,2)")
+    @test contains(sprint(show, MIME"text/plain"(), b), "(1,2,3)")
+    @test contains(sprint(show, MIME"text/plain"(), c), "(4,5)")
+    @test contains(sprint(show, MIME"text/plain"(), b * c), "(1,2,3)(4,5)")
+
+    @testset "optimized definitions for *" begin
+        @testset "seed = $seed" for seed in [1, 2, 3, 4]
+            Random.seed!(seed)
+            p = EP.Perm(Random.randperm(64))
+            q = EP.Perm(Random.randperm(128))
+            r = EP.Perm(Random.randperm(256))
+
+            @test p * q isa EP.Perm
+            @test isperm((p * q).images)
+            @test p * q == EP.Perm([(i^p)^q for i in 1:128])
+
+            @test q * p isa EP.Perm
+            @test isperm((q * p).images)
+            @test q * p == EP.Perm([(i^q)^p for i in 1:128])
+
+            @test p * q * r == p * (q * r)
+            @test p * r * q == p * (r * q)
+            @test r * p * q == r * (p * q)
+
+            @test q * p * r == q * (p * r)
+            @test q * r * p == q * (r * p)
+            @test r * q * p == r * (q * p)
+
+            @test p * q * q * p == (p * q) * (q * p)
+            @test p * q * r * p == (p * q) * (r * p)
+        end
+    end
+end

--- a/test/perms_by_images.jl
+++ b/test/perms_by_images.jl
@@ -40,7 +40,11 @@ function Perm(images::AbstractVector{<:Integer}, check = true)
     return Perm{AP.inttype(Perm)}(images, check)
 end
 
-# we could also define these to make use of lazy-caching of cycle decomposition
+# we also define this function to squeeze more performance
+@inline AP.__unsafe_image(n::Integer, σ::Perm) =
+    oftype(n, @inbounds σ.images[n])
+
+# to make use of lazy-caching of cycle decomposition
 #=
 function AP.cycles(σ::Perm)
     if !isdefined(σ, :cycles)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,4 +25,7 @@ import .ExamplePerms as EP
 
     import .APerms
     abstract_perm_interface_test(APerms.APerm)
+
+    @test convert(APerm, EP.Perm([2, 3, 1])) isa APerm
+    @test convert(APerm, EP.Perm([2, 3, 1])) == EP.Perm([2, 3, 1])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,12 @@
-using AbstractPermutations
-const AP = AbstractPermutations
 using Test
+import Random
 
-include("perms_by_images.jl")
+import AbstractPermutations as AP
+import AbstractPermutations
+include(joinpath(pkgdir(AbstractPermutations), "test", "abstract_perm_API.jl"))
+
+include(joinpath(pkgdir(AbstractPermutations), "test", "perms_by_images.jl"))
 import .ExamplePerms as EP
-include("abstract_perm_API.jl")
 
 @testset "AbstractPermutations.jl" begin
     @testset "incomplete implementation" begin
@@ -15,20 +17,7 @@ include("abstract_perm_API.jl")
         @test_throws AP.InterfaceNotImplemented 3^p
     end
 
-    @testset "ExamplePerms" begin
-        abstract_perm_interface_test(EP.Perm)
-
-        p = EP.Perm([1]) # ()
-        a = EP.Perm([2, 1, 3]) # (1,2)
-        b = EP.Perm([2, 3, 1]) # (1,2,3)
-        c = EP.Perm([1, 2, 3, 5, 4]) # (4,5)
-
-        @test contains(sprint(show, MIME"text/plain"(), p), "()")
-        @test contains(sprint(show, MIME"text/plain"(), a), "(1,2)")
-        @test contains(sprint(show, MIME"text/plain"(), b), "(1,2,3)")
-        @test contains(sprint(show, MIME"text/plain"(), c), "(4,5)")
-        @test contains(sprint(show, MIME"text/plain"(), b * c), "(1,2,3)(4,5)")
-    end
+    include("example_perms_tests.jl")
 
     include("parsing.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,23 +9,17 @@ include(joinpath(pkgdir(AbstractPermutations), "test", "perms_by_images.jl"))
 import .ExamplePerms as EP
 
 @testset "AbstractPermutations.jl" begin
-    @testset "incomplete implementation" begin
-        struct APerm <: AP.AbstractPermutation end
-
-        p = APerm()
-        @test_throws AP.InterfaceNotImplemented AP.degree(p)
-        @test_throws AP.InterfaceNotImplemented 3^p
-    end
-
     include("example_perms_tests.jl")
 
+    @testset "incomplete implementation" begin
+        include("aperm_interface_check.jl")
+        import .APerms.APerm as APerm
+
+        abstract_perm_interface_test(APerm)
+
+        @test convert(APerm, EP.Perm([2, 3, 1])) isa APerm
+        @test convert(APerm, EP.Perm([2, 3, 1])) == EP.Perm([2, 3, 1])
+    end
+
     include("parsing.jl")
-
-    include("aperm_interface_check.jl")
-
-    import .APerms
-    abstract_perm_interface_test(APerms.APerm)
-
-    @test convert(APerm, EP.Perm([2, 3, 1])) isa APerm
-    @test convert(APerm, EP.Perm([2, 3, 1])) == EP.Perm([2, 3, 1])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,20 @@ include("abstract_perm_API.jl")
         @test_throws AP.InterfaceNotImplemented 3^p
     end
 
-    abstract_perm_interface_test(EP.Perm)
+    @testset "ExamplePerms" begin
+        abstract_perm_interface_test(EP.Perm)
+
+        p = EP.Perm([1]) # ()
+        a = EP.Perm([2, 1, 3]) # (1,2)
+        b = EP.Perm([2, 3, 1]) # (1,2,3)
+        c = EP.Perm([1, 2, 3, 5, 4]) # (4,5)
+
+        @test contains(sprint(show, MIME"text/plain"(), p), "()")
+        @test contains(sprint(show, MIME"text/plain"(), a), "(1,2)")
+        @test contains(sprint(show, MIME"text/plain"(), b), "(1,2,3)")
+        @test contains(sprint(show, MIME"text/plain"(), c), "(4,5)")
+        @test contains(sprint(show, MIME"text/plain"(), b * c), "(1,2,3)(4,5)")
+    end
 
     include("parsing.jl")
 


### PR DESCRIPTION
* Introduces optional function `AP.__unsafe_image(i::Integer, p::AbstractPermutation) = i^p` which assumes that `i ∈ Base.OneTo(AP.degree(p))`. This allows skip multiple checks in when e.g. computing the inverse or if the two permutations are equal.
* optimizes `AP.cycles` which are now ~ 2 times faster (starting from N=16)
* the optimized `p*q` is almost (`N=16`: -20%, `N=256`: -6%) as fast as for constant degree permutations (the most favourable context)
* the optimized `p*q*r` is much faster (`N=16`: +78%, `N=256`: +38%) than the naive `p*q*r`
* the `p*q*r*...` vararg method (non-allocating) becomes slower than `Base.afoldl(*, ...)` around `N=128`