### PR TITLE
add methods for efficiently permuting vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractPermutations"
 uuid = "36d08e8a-54dd-435f-8c9e-38a475050b11"
 authors = ["Marek Kaluba <kalmar@mailbox.org>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -10,6 +10,8 @@ iseven(::AbstractPermutation)
 sign(::AbstractPermutation)
 permtype
 cycles
+Base.permute!(::AbstractArray, ::AbstractArray, ::AbstractPermutation)
+Base.permute!(::AbstractArray, ::CycleDecomposition)
 Lex
 DegLex
 ```

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -202,7 +202,7 @@ function Base.getindex(v::AbstractArray, p::AbstractPermutation)
             ),
         )
     end
-    vp = similar(v, length(v))
+    vp = similar(v)
     @inbounds map!(i -> v[i^p], vp, Base.OneTo(degp))
     if degp < length(v)
         copyto!(vp, degp + 1, v, degp + 1, length(v) - degp)

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -183,7 +183,7 @@ end
 Base.broadcastable(p::AbstractPermutation) = Ref(p)
 
 """
-    cycles(g::AbstractPermutation)
+    cycles(g::AbstractPermutation)::CycleDecomposition
 Return an iterator over cycles in the disjoint cycle decomposition of `g`.
 """
 cycles(σ::AbstractPermutation) = CycleDecomposition(σ)
@@ -200,10 +200,12 @@ function Base.getindex(v::AbstractArray, p::AbstractPermutation)
 end
 
 """
-    permute!(dest::AbstractArray, v::AbstracArray, p::AbstractPermutation)
+    permute!(dest::AbstractArray, v::AbstractArray, p::AbstractPermutation)
 Permute array `v` in-place, storing the result in `dest`, according to permutation `p`.
 
-Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
+For the out-of-place version use `v[p]`.
+
+Permutations can be applied to any sufficiently long (`length(v) ≥ degree(p)`) `1`-based array.
 """
 function Base.permute!(
     dest::AbstractArray,

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -205,7 +205,11 @@ Permute array `v` in-place, storing the result in `dest`, according to permutati
 
 Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
-function Base.permute!(dest::AbstractArray, v::AbstractArray, p::AbstractPermutation)
+function Base.permute!(
+    dest::AbstractArray,
+    v::AbstractArray,
+    p::AbstractPermutation,
+)
     Base.require_one_based_indexing(v)
     degp = degree(p)
     if degp > length(v)

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -195,6 +195,17 @@ Permute array `v`, according to permutation `p`.
 Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
 function Base.getindex(v::AbstractArray, p::AbstractPermutation)
+    vp = similar(v)
+    return permute!(vp, v, p)
+end
+
+"""
+    permute!(dest::AbstractArray, v::AbstracArray, p::AbstractPermutation)
+Permute array `v` in-place, storing the result in `dest`, according to permutation `p`.
+
+Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
+"""
+function Base.permute!(dest::AbstractArray, v::AbstractArray, p::AbstractPermutation)
     Base.require_one_based_indexing(v)
     degp = degree(p)
     if degp > length(v)
@@ -204,10 +215,9 @@ function Base.getindex(v::AbstractArray, p::AbstractPermutation)
             ),
         )
     end
-    vp = similar(v)
-    @inbounds map!(i -> v[i^p], vp, Base.OneTo(degp))
+    @inbounds map!(i -> v[i^p], dest, Base.OneTo(degp))
     if degp < length(v)
-        copyto!(vp, degp + 1, v, degp + 1, length(v) - degp)
+        copyto!(dest, degp + 1, v, degp + 1, length(v) - degp)
     end
-    return vp
+    return dest
 end

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -187,3 +187,25 @@ Base.broadcastable(p::AbstractPermutation) = Ref(p)
 Return an iterator over cycles in the disjoint cycle decomposition of `g`.
 """
 cycles(σ::AbstractPermutation) = CycleDecomposition(σ)
+
+"""
+    getindex(v::AbstracArray, p::AbstractPermutation)
+Applies permutation `p` to array `v`.
+"""
+function Base.getindex(v::AbstractArray, p::AbstractPermutation)
+    Base.require_one_based_indexing(v)
+    degp = degree(p)
+    if degp > length(v)
+        throw(
+            ArgumentError(
+                "Cannot permute: Permutation degree is larger than array length",
+            ),
+        )
+    end
+    vp = similar(v, length(v))
+    @inbounds map!(i -> v[i^p], vp, Base.OneTo(degp))
+    if degp < length(v)
+        copyto!(vp, degp + 1, v, degp + 1, length(v) - degp)
+    end
+    return vp
+end

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -190,7 +190,9 @@ cycles(σ::AbstractPermutation) = CycleDecomposition(σ)
 
 """
     getindex(v::AbstracArray, p::AbstractPermutation)
-Applies permutation `p` to array `v`.
+Permute array `v`, according to permutation `p`.
+
+Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
 function Base.getindex(v::AbstractArray, p::AbstractPermutation)
     Base.require_one_based_indexing(v)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -17,7 +17,7 @@ function Base.:(*)(σ::AbstractPermutation, τ::AbstractPermutation)
                 k = (i^σ)^τ
                 @inbounds img[i] = k
             end
-            for i in degree(σ)+1:degree(τ)
+            for i in (degree(σ)+1):degree(τ)
                 k = i^τ
                 @inbounds img[i] = k
             end
@@ -48,11 +48,11 @@ function Base.:(*)(
                 k = ((i^σ)^τ)^ρ
                 @inbounds img[i] = k
             end
-            for i in degσ+1:degτ
+            for i in (degσ+1):degτ
                 k = (i^τ)^ρ
                 @inbounds img[i] = k
             end
-            for i in degτ+1:degρ
+            for i in (degτ+1):degρ
                 k = i^ρ
                 @inbounds img[i] = k
             end
@@ -80,7 +80,7 @@ function Base.:(*)(
                 k = k^ρ
                 @inbounds img[i] = k
             end
-            for i in degσ+1:degρ
+            for i in (degσ+1):degρ
                 k = i^ρ
                 @inbounds img[i] = k
             end

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -70,8 +70,9 @@ Permute array `v`, according to the permutation represented by `cycledec`.
 
 Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
-Base.getindex(v::AbstractArray, cycledec::CycleDecomposition) =
-    permute!(copy(v), cycledec)
+function Base.getindex(v::AbstractArray, cycledec::CycleDecomposition)
+    return permute!(copy(v), cycledec)
+end
 
 """
     permute!(v::AbstractArray, cycledec::CycleDecomposition)
@@ -92,7 +93,7 @@ function Base.permute!(v::AbstractArray, cycledec::CycleDecomposition)
         length_c = length(c)
         @inbounds if length_c > 1
             temp = v[c[1]]
-            for i in 1:length_c-1
+            for i in 1:(length_c-1)
                 v[c[i]] = v[c[i+1]]
             end
             v[c[length_c]] = temp

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -69,7 +69,7 @@ end
 Applies permutation with cycle decomposition `cycledec` to array `v`.
 """
 Base.getindex(v::AbstractArray, cycledec::CycleDecomposition) =
-    vec(permute!(copy(v), cycledec))
+    permute!(copy(v), cycledec)
 
 """
     permute!(v::AbstractArray, cycledec::CycleDecomposition)

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -78,7 +78,9 @@ end
     permute!(v::AbstractArray, cycledec::CycleDecomposition)
 Permute array `v` in-place, according to the permutation represented by `cycledec`.
 
-Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
+For the out-of-place version use `v[p]`.
+
+Permutations can be applied to any sufficiently long (`length(v) ≥ degree(p)`) `1`-based array.
 """
 function Base.permute!(v::AbstractArray, cycledec::CycleDecomposition)
     Base.require_one_based_indexing(v)

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -66,14 +66,18 @@ end
 
 """
     getindex(v::AbstractArray, cycledec::CycleDecomposition)
-Applies permutation with cycle decomposition `cycledec` to array `v`.
+Permute array `v`, according to the permutation represented by `cycledec`.
+
+Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
 Base.getindex(v::AbstractArray, cycledec::CycleDecomposition) =
     permute!(copy(v), cycledec)
 
 """
     permute!(v::AbstractArray, cycledec::CycleDecomposition)
-Applies permutation with cycle decomposition `cycledec` to array `v`, without allocating.
+Permute array `v` in-place, according to the permutation represented by `cycledec`.
+
+Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
 function Base.permute!(v::AbstractArray, cycledec::CycleDecomposition)
     Base.require_one_based_indexing(v)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -10,7 +10,7 @@ function _parse_cycles(str::AbstractString)
     for m in eachmatch(cycle_regex, str)
         cycle_str = m.match
         parsed_size += sizeof(cycle_str)
-        cycle = [parse(Int, a) for a in split(cycle_str[2:end-1], ",")]
+        cycle = [parse(Int, a) for a in split(cycle_str[2:(end-1)], ",")]
         push!(cycles, cycle)
     end
     if parsed_size != sizeof(str)

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -126,11 +126,10 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
             M = randn(2, 3)
             for p in (id, a, b, c, d), arr in (v, M)
                 cycledec = AP.cycles(p)
-                image = (1:6) .^ p
+                image = reshape((1:6) .^ p, size(arr))
                 @test arr[p] == arr[image]
                 @test arr[cycledec] == arr[image]
-                @test permute!(copy(arr), cycledec) ==
-                      reshape(arr[image], size(arr))
+                @test permute!(copy(arr), cycledec) == arr[image]
             end
         end
 

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -131,6 +131,8 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
                 @test arr[cycledec] == arr[image]
                 @test permute!(copy(arr), cycledec) == arr[image]
             end
+            @test_throws ArgumentError v[1:1][a]
+            @test_throws ArgumentError M[1:2, 1:2][AP.cycles(d)]
         end
 
         @testset "permutation functions" begin

--- a/test/abstract_perm_API.jl
+++ b/test/abstract_perm_API.jl
@@ -116,6 +116,24 @@ function abstract_perm_interface_test(P::Type{<:AP.AbstractPermutation})
             @test AP.fixedpoints(id, 5:7) == 5:7
         end
 
+        @testset "actions on arrays" begin
+            id = P([1]) # ()
+            a = P([2, 1, 3]) # (1,2)
+            b = P([2, 3, 1]) # (1,2,3)
+            c = P([1, 2, 3, 5, 4]) # (4,5)
+            d = P([1, 3, 2, 4, 6, 5]) # (2,3)(5,6)
+            v = randn(6)
+            M = randn(2, 3)
+            for p in (id, a, b, c, d), arr in (v, M)
+                cycledec = AP.cycles(p)
+                image = (1:6) .^ p
+                @test arr[p] == arr[image]
+                @test arr[cycledec] == arr[image]
+                @test permute!(copy(arr), cycledec) ==
+                      reshape(arr[image], size(arr))
+            end
+        end
+
         @testset "permutation functions" begin
             id = P([1]) # ()
             a = P([2, 1, 3]) # (1,2)

--- a/test/perms_by_images.jl
+++ b/test/perms_by_images.jl
@@ -41,7 +41,7 @@ AP.inttype(::Type{Perm{T}}) where {T} = T
 @inline AP.__unsafe_image(n::Integer, σ::Perm) =
     oftype(n, @inbounds σ.images[n])
 
-# this is only for our convienience, NOT REQUIRED
+# this is only for our convenience, NOT REQUIRED
 function Perm(images::AbstractVector{<:Integer}; check = true)
     return Perm{UInt16}(images; check = check)
 end


### PR DESCRIPTION
Closes kalmarek/PermutationGroups.jl#47

I've added `getindex` for `AbstractPermutation` and `CycleDecomposition`, and `permute!` for the latter only.