### PR TITLE
allow other vector types for `CycleDecomposition`

### DIFF
--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -1,7 +1,14 @@
-struct CycleDecomposition{T<:Integer} <:
-       AbstractVector{SubArray{T,1,Vector{T},Tuple{UnitRange{Int64}},true}}
-    cycles::Vector{T} # cycles, concatenated
-    cycles_ptrs::Vector{T} # pointers to the starts of the cycles
+struct CycleDecomposition{T<:Integer,V<:AbstractVector{T}} <:
+       AbstractVector{SubArray{T,1,V,Tuple{UnitRange{Int64}},true}}
+    cycles::V # cycles, concatenated
+    cycles_ptrs::V # pointers to the starts of the cycles
+end
+
+function CycleDecomposition{T}(
+    cycles::V,
+    cycles_ptrs::V,
+) where {T<:Integer,V<:AbstractVector{T}}
+    return CycleDecomposition{T,V}(cycles, cycles_ptrs)
 end
 
 degree(cd::CycleDecomposition) = length(cd.cycles)


### PR DESCRIPTION
This is the first of two variants for getting allocation-free cycle decompositions; the other one being #28. This one is supposed to be used with the branch `cycles1` of [SmallPermutations.jl](https://github.com/matthias314/SmallPermutations.jl).

In this variant, the type `CycleDecomposition{T}` gets a second parameter `V` (`CycleDecomposition{T,V}`) that indicates the vector type on which the views in the cycle decomposition are based. So far this vector type has always been `Vector{T}`; for `SmallPermutations{N}` it would be `FixedVector{N,UInt8}`.

The advantage of this option is that it requires only little changes to AbstractPermutations.jl. A disadvantage is that `CycleDecomposition{T}` is not a concrete type anymore. This may lead to performance degradation in downstream code unless it is updated. Another disadvantage is that this approach is less flexible than the other variant in that the elements of the cycle decomposition have to be views into some vector type.

To motivate the whole change (for either variant), here is a performance comparison between `Perm` and `SmallPermutation`:
```
julia> using PermutationGroups, SmallPermutations, Random, Chairmarks

julia> using AbstractPermutations: cycles

julia> N = 32; v = [randperm(N) for _ in 1:1000];

julia> @b Perm{UInt8}.(v) sum(length∘cycles, _) evals = 1
243.839 μs (8867 allocs: 326.047 KiB)

julia> @b SmallPermutation{N}.(v) sum(length∘cycles, _)
80.663 μs
```