### PR TITLE
added `AbstractCycleDecomposition`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractPermutations"
 uuid = "36d08e8a-54dd-435f-8c9e-38a475050b11"
 authors = ["Marek Kaluba <kalmar@mailbox.org>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"

--- a/src/abstract_perm.jl
+++ b/src/abstract_perm.jl
@@ -183,7 +183,7 @@ end
 Base.broadcastable(p::AbstractPermutation) = Ref(p)
 
 """
-    cycles(g::AbstractPermutation)::CycleDecomposition
+    cycles(g::AbstractPermutation)::AbstractCycleDecomposition
 Return an iterator over cycles in the disjoint cycle decomposition of `g`.
 """
 cycles(σ::AbstractPermutation) = CycleDecomposition(σ)

--- a/src/cycle_decomposition.jl
+++ b/src/cycle_decomposition.jl
@@ -1,5 +1,10 @@
-struct CycleDecomposition{T<:Integer} <:
-       AbstractVector{SubArray{T,1,Vector{T},Tuple{UnitRange{Int64}},true}}
+abstract type AbstractCycleDecomposition{T<:Integer,V<:AbstractVector{T}} <:
+              AbstractVector{V} end
+
+struct CycleDecomposition{T<:Integer} <: AbstractCycleDecomposition{
+    T,
+    SubArray{T,1,Vector{T},Tuple{UnitRange{Int64}},true},
+}
     cycles::Vector{T} # cycles, concatenated
     cycles_ptrs::Vector{T} # pointers to the starts of the cycles
 end
@@ -8,7 +13,7 @@ degree(cd::CycleDecomposition) = length(cd.cycles)
 
 Base.size(cd::CycleDecomposition) = (length(cd.cycles_ptrs) - 1,)
 
-Base.IndexStyle(::Type{<:CycleDecomposition}) = IndexLinear()
+Base.IndexStyle(::Type{<:AbstractCycleDecomposition}) = IndexLinear()
 
 @inline function Base.getindex(cd::CycleDecomposition, i::Int)
     @boundscheck checkbounds(cd, i)
@@ -17,7 +22,7 @@ Base.IndexStyle(::Type{<:CycleDecomposition}) = IndexLinear()
     return @inbounds @view(cd.cycles[from:to])
 end
 
-function Base.show(io::IO, cd::CycleDecomposition)
+function Base.show(io::IO, cd::AbstractCycleDecomposition)
     print(io, "Cycle Decomposition: ")
     for c in cd
         print(io, '(')
@@ -65,24 +70,24 @@ function CycleDecomposition(σ::AbstractPermutation)
 end
 
 """
-    getindex(v::AbstractArray, cycledec::CycleDecomposition)
+    getindex(v::AbstractArray, cycledec::AbstractCycleDecomposition)
 Permute array `v`, according to the permutation represented by `cycledec`.
 
 Permutations can be applied to any `1`-based array such that that `length(v) ≥ degree(p)`.
 """
-function Base.getindex(v::AbstractArray, cycledec::CycleDecomposition)
+function Base.getindex(v::AbstractArray, cycledec::AbstractCycleDecomposition)
     return permute!(copy(v), cycledec)
 end
 
 """
-    permute!(v::AbstractArray, cycledec::CycleDecomposition)
+    permute!(v::AbstractArray, cycledec::AbstractCycleDecomposition)
 Permute array `v` in-place, according to the permutation represented by `cycledec`.
 
 For the out-of-place version use `v[p]`.
 
 Permutations can be applied to any sufficiently long (`length(v) ≥ degree(p)`) `1`-based array.
 """
-function Base.permute!(v::AbstractArray, cycledec::CycleDecomposition)
+function Base.permute!(v::AbstractArray, cycledec::AbstractCycleDecomposition)
     Base.require_one_based_indexing(v)
     if degree(cycledec) > length(v)
         throw(

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -5,7 +5,7 @@ Return `true` if g is an odd permutation and `false` otherwise.
 An odd permutation decomposes into an odd number of transpositions.
 """
 Base.isodd(σ::AbstractPermutation) = __isodd(σ)
-Base.isodd(cd::CycleDecomposition) = isodd(count(iseven ∘ length, cd))
+Base.isodd(cd::AbstractCycleDecomposition) = isodd(count(iseven ∘ length, cd))
 
 """
     isodd(g::AbstractPermutation) -> Bool
@@ -14,7 +14,7 @@ Return `true` if g is an even permutation and `false` otherwise.
 An even permutation decomposes into an even number of transpositions.
 """
 Base.iseven(σ::AbstractPermutation) = !isodd(σ)
-Base.iseven(cd::CycleDecomposition) = !isodd(cd)
+Base.iseven(cd::AbstractCycleDecomposition) = !isodd(cd)
 
 function __isodd(σ::AbstractPermutation)
     to_visit = trues(degree(σ))
@@ -93,7 +93,7 @@ function GroupsCore.order(::Type{T}, σ::AbstractPermutation) where {T}
     return GroupsCore.order(T, cycles(σ))
 end
 
-GroupsCore.order(cd::CycleDecomposition) = GroupsCore.order(BigInt, cd)
-function GroupsCore.order(::Type{T}, cd::CycleDecomposition) where {T}
+GroupsCore.order(cd::AbstractCycleDecomposition) = GroupsCore.order(BigInt, cd)
+function GroupsCore.order(::Type{T}, cd::AbstractCycleDecomposition) where {T}
     return convert(T, mapreduce(length, lcm, cd; init = 1))
 end


### PR DESCRIPTION
This is the second of two variants for getting allocation-free cycle decompositions; the other one being #27. This one is supposed to be used with the branch `cycles2` of [SmallPermutations.jl](https://github.com/matthias314/SmallPermutations.jl).

In this variant, a new abstract type `AbstractCycleDecomposition{T}` is introduced and `CycleDecomposition{T}` is made a subtype of it. SmallPermutations.jl then adds `SmallCycleDecomposition` that is used with `SmallPermutation`. Some functions in AbstractPermutations.jl are now accepting `AbstractCycleDecomposition`, others are kept for `CycleDecomposition`.

This option requires slightly more changes to AbstractPermutations.jl and some code duplication in SmallPermutations.jl. Also, downstream code should now use the function `cycles` to compute cycle decomposition instead of the constructor `CycleDecomposition`. On the other hand, this approach may be cleaner and more "future-proof" than the other variant in that it allows other cycle decomposition types.

Performance is identical to #27.