### PR TITLE
faster `isodd` for `CycleDecomposition`

### DIFF
--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -5,7 +5,10 @@ Return `true` if g is an odd permutation and `false` otherwise.
 An odd permutation decomposes into an odd number of transpositions.
 """
 Base.isodd(σ::AbstractPermutation) = __isodd(σ)
-Base.isodd(cd::CycleDecomposition) = isodd(count(iseven ∘ length, cd))
+
+function Base.isodd(cd::CycleDecomposition)
+    return iseven(length(cd.cycles) + length(cd.cycles_ptrs))
+end
 
 """
     isodd(g::AbstractPermutation) -> Bool

--- a/src/perm_functionality.jl
+++ b/src/perm_functionality.jl
@@ -5,7 +5,10 @@ Return `true` if g is an odd permutation and `false` otherwise.
 An odd permutation decomposes into an odd number of transpositions.
 """
 Base.isodd(σ::AbstractPermutation) = __isodd(σ)
-Base.isodd(cd::AbstractCycleDecomposition) = isodd(count(iseven ∘ length, cd))
+
+function Base.isodd(cd::AbstractCycleDecomposition)
+    return isodd(degree(cd) + length(cd))
+end
 
 """
     isodd(g::AbstractPermutation) -> Bool


### PR DESCRIPTION
Writing `v = cd.cycles_ptr`, the original formula is the same as
```
isodd(sum(v[i+1]-v[i]-1 for i in 1:length(v)-1))
```
which simplifies to
```
isodd(v[1] + v[end] + length(v)-1)
```
Now `v[1] == 1` and `v[end] == length(cd.cycles)+1`, which gives
```
iseven(length(cd.cycles) + length(v))
```